### PR TITLE
halo2 backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,11 @@ members = [
     "pil_analyzer",
     "compiler",
     "pilgen",
+    "halo2"
 ]
+
+[patch."https://github.com/privacy-scaling-explorations/halo2.git"]
+halo2_proofs = { git ="https://github.com/ed255/halo2", rev = "63e969673de83a410f21553fabec8f4b35bda1a5" }
+
+[patch.crates-io]
+halo2_proofs = { git ="https://github.com/ed255/halo2", rev = "63e969673de83a410f21553fabec8f4b35bda1a5" }

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -2,16 +2,17 @@
 
 use std::ffi::OsStr;
 use std::fs;
-use std::io::{BufWriter, Write};
+use std::io::BufWriter;
 use std::path::Path;
 use std::time::Instant;
 
 mod verify;
+use number::write_polys_file;
 use pil_analyzer::json_exporter;
 pub use verify::{compile_asm_string_temp, verify, verify_asm_string};
 
 use executor::constant_evaluator;
-use number::{DegreeType, FieldElement};
+use number::FieldElement;
 use parser::ast::PILFile;
 
 pub fn no_callback<T>() -> Option<fn(&str) -> Option<T>> {
@@ -158,20 +159,6 @@ fn compile<T: FieldElement>(
         .unwrap();
     log::info!("Wrote {}.", json_file.to_string_lossy());
     success
-}
-
-fn write_polys_file<T: FieldElement>(
-    file: &mut impl Write,
-    degree: DegreeType,
-    polys: &Vec<(&str, Vec<T>)>,
-) {
-    for i in 0..degree as usize {
-        for (_name, constant) in polys {
-            let bytes = constant[i].to_bytes_le();
-            assert_eq!(bytes.len(), 8);
-            file.write_all(&bytes).unwrap();
-        }
-    }
 }
 
 fn inputs_to_query_callback<T: FieldElement>(inputs: Vec<T>) -> impl Fn(&str) -> Option<T> {

--- a/executor/src/witgen/bit_constraints.rs
+++ b/executor/src/witgen/bit_constraints.rs
@@ -1,7 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::{Debug, Display, Formatter};
 
-use crate::witgen::util::contains_next_ref;
 use number::{log2_exact, BigInt, FieldElement};
 use pil_analyzer::{BinaryOperator, Expression, Identity, IdentityKind, PolynomialReference};
 
@@ -286,7 +285,7 @@ fn try_transfer_constraints<'a, 'b, T: FieldElement>(
     expr: &'a Expression<T>,
     known_constraints: &'b BTreeMap<&'b PolynomialReference, BitConstraint<T>>,
 ) -> Option<(&'a PolynomialReference, BitConstraint<T>)> {
-    if contains_next_ref(expr) {
+    if expr.contains_next_ref() {
         return None;
     }
 

--- a/executor/src/witgen/generator.rs
+++ b/executor/src/witgen/generator.rs
@@ -114,15 +114,13 @@ where
                     .into()
                 });
 
-                if result.is_err() {
-                    identity_failed = true;
-                }
-
                 match &result {
-                    Ok(e) if e.is_complete() => {
-                        *complete = true;
+                    Ok(e) => {
+                        *complete = e.is_complete();
                     }
-                    _ => {}
+                    Err(_) => {
+                        identity_failed = true;
+                    }
                 };
 
                 self.handle_eval_result(result);
@@ -150,7 +148,7 @@ where
         }
         // Identity check failure on the first row is not fatal. We will proceed with
         // "unknown", report zero and re-check the wrap-around against the zero values at the end.
-        if identity_failed && next_row != 0 {
+        if identity_failed {
             log::error!(
                 "\nError: Row {next_row}: Identity check failed or unable to derive values for some witness columns.\nSet RUST_LOG=debug for more information.");
             log::debug!(

--- a/executor/src/witgen/generator.rs
+++ b/executor/src/witgen/generator.rs
@@ -12,7 +12,6 @@ use super::bit_constraints::{BitConstraint, BitConstraintSet};
 use super::expression_evaluator::ExpressionEvaluator;
 use super::machines::{FixedLookup, Machine};
 use super::symbolic_witness_evaluator::{SymoblicWitnessEvaluator, WitnessColumnEvaluator};
-use super::util::contains_next_witness_ref;
 use super::{Constraint, EvalResult, EvalValue, FixedData, IncompleteCause, WitnessColumn};
 
 pub struct Generator<'a, T: FieldElement, QueryCallback> {
@@ -146,8 +145,6 @@ where
                 break;
             }
         }
-        // Identity check failure on the first row is not fatal. We will proceed with
-        // "unknown", report zero and re-check the wrap-around against the zero values at the end.
         if identity_failed {
             log::error!(
                 "\nError: Row {next_row}: Identity check failed or unable to derive values for some witness columns.\nSet RUST_LOG=debug for more information.");
@@ -357,7 +354,7 @@ where
     fn process_polynomial_identity<'b>(&self, identity: &'b Expression<T>) -> EvalResult<'b, T> {
         // If there is no "next" reference in the expression,
         // we just evaluate it directly on the "next" row.
-        let row = if contains_next_witness_ref(identity) {
+        let row = if identity.contains_next_witness_ref() {
             // TODO this is the only situation where we use "current"
             // TODO this is the only that actually uses a window.
             EvaluationRow::Current

--- a/executor/src/witgen/machines/fixed_lookup_machine.rs
+++ b/executor/src/witgen/machines/fixed_lookup_machine.rs
@@ -8,8 +8,8 @@ use pil_analyzer::{Identity, IdentityKind, PolyID, PolynomialReference, Selected
 
 use crate::witgen::affine_expression::AffineResult;
 use crate::witgen::util::try_to_simple_poly_ref;
-use crate::witgen::{util::contains_witness_ref, EvalResult, FixedData};
 use crate::witgen::{EvalError, EvalValue, IncompleteCause};
+use crate::witgen::{EvalResult, FixedData};
 
 type Application = (Vec<u64>, Vec<u64>);
 type Index<T> = BTreeMap<Vec<T>, IndexValue>;
@@ -185,7 +185,7 @@ impl<T: FieldElement> FixedLookup<T> {
         // This is a matching machine if it is a plookup and the RHS is fully constant.
         if kind != IdentityKind::Plookup
             || right.selector.is_some()
-            || right.expressions.iter().any(contains_witness_ref)
+            || right.expressions.iter().any(|e| e.contains_witness_ref())
         {
             return None;
         }

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -118,12 +118,6 @@ pub fn generate<'a, T: FieldElement>(
             values[col].1.push(v);
         }
     }
-    for (col, v) in generator.compute_next_row(0).into_iter().enumerate() {
-        if v != values[col].1[0] {
-            eprintln!("Wrap-around value for column {} does not match: {} (wrap-around) vs. {} (first row).",
-            witness_cols[col].poly, v, values[col].1[0]);
-        }
-    }
     for (name, data) in generator.machine_witness_col_values() {
         let (_, col) = values.iter_mut().find(|(n, _)| *n == name).unwrap();
         *col = data;

--- a/executor/src/witgen/util.rs
+++ b/executor/src/witgen/util.rs
@@ -1,32 +1,7 @@
 use std::collections::HashMap;
 
-use pil_analyzer::util::{expr_any, previsit_expressions_in_identity_mut};
+use pil_analyzer::util::previsit_expressions_in_identity_mut;
 use pil_analyzer::{Expression, Identity, PolyID, PolynomialReference};
-
-/// @returns true if the expression contains a reference to a next value of a
-/// (witness or fixed) column
-pub fn contains_next_ref<T>(expr: &Expression<T>) -> bool {
-    expr_any(expr, |e| match e {
-        Expression::PolynomialReference(poly) => poly.next,
-        _ => false,
-    })
-}
-
-/// @returns true if the expression contains a reference to a next value of a witness column.
-pub fn contains_next_witness_ref<T>(expr: &Expression<T>) -> bool {
-    expr_any(expr, |e| match e {
-        Expression::PolynomialReference(poly) => poly.next && poly.is_witness(),
-        _ => false,
-    })
-}
-
-/// @returns true if the expression contains a reference to a witness column.
-pub fn contains_witness_ref<T>(expr: &Expression<T>) -> bool {
-    expr_any(expr, |e| match e {
-        Expression::PolynomialReference(poly) => poly.is_witness(),
-        _ => false,
-    })
-}
 
 /// Checks if an expression is
 /// - a polynomial

--- a/halo2/Cargo.toml
+++ b/halo2/Cargo.toml
@@ -6,16 +6,18 @@ edition = "2021"
 [dependencies]
 number = { path = "../number" }
 pil_analyzer = { path = "../pil_analyzer" }
-executor = { path = "../executor" }
-pilgen = { path = "../pilgen" }
 polyexen = { git = "https://github.com/Dhole/polyexen", rev="c4864d2debf9ae21138c9d67a99c93c3362df19b"}
 halo2_proofs = "0.2"
-prettytable = "0.10.0"
 num-traits = "0.2.15"
 num-integer = "0.1.45"
 itertools = "0.10.5"
 num-bigint = "^0.4"
 log = "0.4.17"
+rand = "0.8.5"
+
+[dev-dependencies]
+executor = { path = "../executor" }
+pilgen = { path = "../pilgen" }
 
 [build-dependencies]
 lalrpop = "^0.19"

--- a/halo2/Cargo.toml
+++ b/halo2/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "halo2"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+number = { path = "../number" }
+pil_analyzer = { path = "../pil_analyzer" }
+executor = { path = "../executor" }
+pilgen = { path = "../pilgen" }
+polyexen = { git = "https://github.com/Dhole/polyexen", rev="c4864d2debf9ae21138c9d67a99c93c3362df19b"}
+halo2_proofs = "0.2"
+prettytable = "0.10.0"
+num-traits = "0.2.15"
+num-integer = "0.1.45"
+itertools = "0.10.5"
+num-bigint = "^0.4"
+log = "0.4.17"
+
+[build-dependencies]
+lalrpop = "^0.19"

--- a/halo2/src/circuit_builder.rs
+++ b/halo2/src/circuit_builder.rs
@@ -1,0 +1,234 @@
+use num_bigint::BigUint;
+use polyexen::expr::{ColumnKind, Expr, PlonkVar};
+use polyexen::plaf::backends::halo2::PlafH2Circuit;
+use polyexen::plaf::{ColumnFixed, ColumnWitness, Columns, Info, Lookup, Plaf, Poly, Witness};
+
+use num_traits::One;
+use number::{BigInt, FieldElement};
+use pil_analyzer::{self, BinaryOperator, Expression, IdentityKind};
+
+use super::circuit_data::CircuitData;
+
+pub(crate) fn analyzed_to_circuit<T: FieldElement>(
+    analyzed: &pil_analyzer::Analyzed<T>,
+    query_callback: Option<impl FnMut(&str) -> Option<T>>,
+) -> PlafH2Circuit {
+    // The structure of the table is as following
+    //
+    // | constant columns | __enable_cur | __enable_next |  witness columns | \
+    // |  bla_bla_bla     |    1         |       1       |   bla_bla_bla    |  |
+    // |  bla_bla_bla     |    1         |       1       |   bla_bla_bla    |  |>  witness + fixed  2^(k-1)
+    // |  ...             |   ...        |      ...      |   ...            |  |
+    // |  bla_bla_bla     |    1         |       0       |   bla_bla_bla    | /     <- __enable_next == 0 since there's no state transition
+    // |  0               |    0         |       0       |   0              | \
+    // |  0               |    0         |       0       |   0              |  |
+    // |  ...             |   ...        |      ...      |   ...            |  |> 2^2-1
+    // |  0               |    0         |       0       |   <unusable>     |  |
+    // |  0               |    0         |       0       |   <unusable>     | /
+
+    // generate fixed and witness (witness).
+
+    let query = |column, rotation| Expr::Var(PlonkVar::ColumnQuery { column, rotation });
+
+    let (fixed, degree) = executor::constant_evaluator::generate(analyzed);
+    let witness = executor::witgen::generate(analyzed, degree, &fixed, query_callback);
+
+    let mut cd = CircuitData::from(fixed, witness);
+
+    // append to fixed columns:
+    // - one that enables constraints that do not have rotations
+    // - and another that enables constraints that have a rotation
+    // (note this is not activated) in last row.
+
+    let num_rows = cd.len();
+
+    let q_enable_cur = query(
+        cd.insert_constant("__enable_cur", itertools::repeat_n(T::from(1), num_rows)),
+        0,
+    );
+
+    let q_enable_next = query(
+        cd.insert_constant(
+            "__enable_next",
+            itertools::repeat_n(T::from(1), num_rows - 1).chain(std::iter::once(T::from(0))),
+        ),
+        0,
+    );
+
+    let mut lookups = vec![];
+    let mut polys = vec![];
+
+    // build Plaf columns -------------------------------------------------
+
+    let columns = Columns {
+        fixed: cd
+            .fixed
+            .iter()
+            .map(|(name, _)| ColumnFixed::new(name.to_string()))
+            .collect(),
+        witness: cd
+            .witness
+            .iter()
+            .map(|(name, _)| ColumnWitness::new(name.to_string(), 0))
+            .collect(),
+        public: vec![],
+    };
+
+    // build Plaf info. -------------------------------------------------------------------------
+
+    let info = Info {
+        p: T::modulus().to_arbitrary_integer(),
+        num_rows: cd.len(),
+        challenges: vec![],
+    };
+
+    // build Plaf polys. -------------------------------------------------------------------------
+
+    for id in &analyzed.identities {
+        if id.kind == IdentityKind::Polynomial {
+            // polynomial identities.
+
+            assert_eq!(id.right.expressions.len(), 0);
+            assert_eq!(id.right.selector, None);
+            assert_eq!(id.left.expressions.len(), 0);
+
+            let (exp, is_next) = expression_2_expr(&cd, id.left.selector.as_ref().unwrap());
+
+            // depending whether this polynomial contains a rotation,
+            // enable for all rows or all except the last one.
+
+            let exp = Expr::Mul(vec![
+                exp,
+                if is_next {
+                    q_enable_next.clone()
+                } else {
+                    q_enable_cur.clone()
+                },
+            ]);
+            polys.push(Poly {
+                name: "".to_string(),
+                exp,
+            });
+        } else if id.kind == IdentityKind::Plookup {
+            // lookups.
+
+            assert_eq!(id.right.selector, None);
+
+            let left_selector = id
+                .left
+                .selector
+                .clone()
+                .map_or(Expr::Const(BigUint::one()), |expr| {
+                    expression_2_expr(&cd, &expr).0
+                });
+
+            let left = id
+                .left
+                .expressions
+                .iter()
+                .map(|expr| left_selector.clone() * expression_2_expr(&cd, expr).0)
+                .collect();
+
+            let right = id
+                .right
+                .expressions
+                .iter()
+                .map(|expr| expression_2_expr(&cd, expr).0)
+                .collect();
+
+            lookups.push(Lookup {
+                name: "".to_string(),
+                exps: (left, right),
+            });
+        } else {
+            unimplemented!()
+        }
+    }
+
+    // build Plaf fixed. -------------------------------------------------------------------------
+
+    let fixed: Vec<Vec<_>> = cd
+        .fixed
+        .iter()
+        .map(|(_, row)| {
+            row.iter()
+                .map(|value| Some(value.to_arbitrary_integer()))
+                .collect()
+        })
+        .collect();
+
+    // build witness. -------------------------------------------------------------------------
+
+    let witness: Vec<Vec<_>> = cd
+        .witness
+        .iter()
+        .map(|(_, row)| {
+            row.iter()
+                .map(|value| Some(value.to_arbitrary_integer()))
+                .collect()
+        })
+        .collect();
+
+    let witness_cols = cd
+        .witness
+        .iter()
+        .enumerate()
+        .map(|(n, (name, _))| (name.to_string(), (ColumnKind::Fixed, n)));
+
+    let wit = Witness {
+        num_rows: cd.witness.len(),
+        columns: witness_cols
+            .map(|(name, _)| ColumnWitness::new(name, 0))
+            .collect(),
+        witness,
+    };
+
+    let copys = vec![];
+
+    // build plaf. -------------------------------------------------------------------------
+
+    let plaf = Plaf {
+        info,
+        columns,
+        polys,
+        lookups,
+        copys,
+        fixed,
+    };
+
+    // return circuit description + witness. -------------
+
+    PlafH2Circuit { plaf, wit }
+}
+
+fn expression_2_expr<T: FieldElement>(
+    cd: &CircuitData<T>,
+    expr: &Expression<T>,
+) -> (Expr<PlonkVar>, bool) {
+    match expr {
+        Expression::Number(n) => (Expr::Const(n.to_arbitrary_integer()), false),
+        Expression::PolynomialReference(polyref) => {
+            assert_eq!(polyref.index, None);
+
+            let plonkvar = PlonkVar::ColumnQuery {
+                column: cd.col(&polyref.name),
+                rotation: polyref.next as i32,
+            };
+
+            (Expr::Var(plonkvar), polyref.next)
+        }
+        Expression::BinaryOperation(lhe, op, rhe) => {
+            let (lhe, lhe_rot) = expression_2_expr(cd, lhe);
+            let (rhe, rhe_rot) = expression_2_expr(cd, rhe);
+            let res = match op {
+                BinaryOperator::Add => Expr::Sum(vec![lhe, rhe]),
+                BinaryOperator::Sub => Expr::Sum(vec![lhe, Expr::Neg(Box::new(rhe))]),
+                BinaryOperator::Mul => Expr::Mul(vec![lhe, rhe]),
+                _ => unimplemented!("{:?}", expr),
+            };
+            (res, std::cmp::max(lhe_rot, rhe_rot))
+        }
+
+        _ => unimplemented!("{:?}", expr),
+    }
+}

--- a/halo2/src/circuit_data.rs
+++ b/halo2/src/circuit_data.rs
@@ -1,0 +1,107 @@
+#![allow(unused)]
+
+use std::collections::HashMap;
+
+use num_bigint::BigInt;
+use number::{AbstractNumberType, FieldElement};
+use polyexen::expr::{Column, ColumnKind};
+
+pub(crate) struct CircuitData<'a, T> {
+    pub(crate) fixed: Vec<(&'a str, Vec<T>)>,
+    pub(crate) witness: Vec<(&'a str, Vec<T>)>,
+    columns: HashMap<String, Column>,
+}
+
+impl<'a, T: FieldElement> CircuitData<'a, T> {
+    pub fn from(fixed: Vec<(&'a str, Vec<T>)>, witness: Vec<(&'a str, Vec<T>)>) -> Self {
+        assert_eq!(
+            fixed.get(0).unwrap().1.len(),
+            witness.get(0).unwrap().1.len()
+        );
+
+        let const_cols = fixed.iter().enumerate().map(|(index, (name, _))| {
+            (
+                name.to_string(),
+                Column {
+                    kind: ColumnKind::Fixed,
+                    index,
+                },
+            )
+        });
+
+        let witness_cols = witness.iter().enumerate().map(|(index, (name, _))| {
+            (
+                name.to_string(),
+                Column {
+                    kind: ColumnKind::Witness,
+                    index,
+                },
+            )
+        });
+
+        let columns = const_cols.chain(witness_cols).collect();
+
+        Self {
+            fixed,
+            witness,
+            columns,
+        }
+    }
+
+    pub fn col(&self, name: &str) -> Column {
+        *self
+            .columns
+            .get(name)
+            .unwrap_or_else(|| panic!("{name} column not found"))
+    }
+
+    pub fn val(&self, column: &Column, offset: usize) -> &T {
+        match column.kind {
+            ColumnKind::Fixed => self.fixed.get(column.index).unwrap().1.get(offset).unwrap(),
+            ColumnKind::Witness => self
+                .witness
+                .get(column.index)
+                .unwrap()
+                .1
+                .get(offset)
+                .unwrap(),
+            _ => unimplemented!(),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.fixed.get(0).unwrap().1.len()
+    }
+
+    pub fn insert_constant<IT: IntoIterator<Item = T>>(
+        &mut self,
+        name: &'a str,
+        values: IT,
+    ) -> Column {
+        let values = values.into_iter().collect::<Vec<_>>();
+        assert_eq!(values.len(), self.len());
+        self.fixed.push((name, values));
+        let column = Column {
+            kind: ColumnKind::Fixed,
+            index: self.fixed.len() - 1,
+        };
+        self.columns.insert(name.to_string(), column);
+        column
+    }
+
+    pub fn insert_commit<IT: IntoIterator<Item = T>>(
+        &mut self,
+        name: &'a str,
+        values: IT,
+    ) -> Column {
+        let values = values.into_iter().collect::<Vec<_>>();
+        assert_eq!(values.len(), self.len());
+        self.witness.push((name, values));
+        let column = Column {
+            kind: ColumnKind::Witness,
+            index: self.witness.len() - 1,
+        };
+        self.columns.insert(name.to_string(), column);
+        column
+    }
+}

--- a/halo2/src/lib.rs
+++ b/halo2/src/lib.rs
@@ -1,0 +1,5 @@
+pub(crate) mod circuit_builder;
+pub(crate) mod circuit_data;
+pub(crate) mod mock_prover;
+
+pub use mock_prover::mock_prove_asm;

--- a/halo2/src/lib.rs
+++ b/halo2/src/lib.rs
@@ -2,4 +2,4 @@ pub(crate) mod circuit_builder;
 pub(crate) mod circuit_data;
 pub(crate) mod mock_prover;
 
-pub use mock_prover::mock_prove_asm;
+pub use mock_prover::mock_prove;

--- a/halo2/src/mock_prover.rs
+++ b/halo2/src/mock_prover.rs
@@ -1,48 +1,15 @@
-use std::fs;
+use std::{fs::File, path::Path};
 
+use number::read_polys_file;
+use pil_analyzer::Analyzed;
 use polyexen::plaf::PlafDisplayBaseTOML;
 
 use super::circuit_builder::analyzed_to_circuit;
 use halo2_proofs::{dev::MockProver, halo2curves::bn256::Fr};
 use number::{BigInt, Bn254Field, FieldElement};
 
-// Follow dependency installation instructions from https://github.com/ed255/polyexen-demo
-
-//const MAX_PUBLIC_INPUTS: usize = 12;
-
-pub fn mock_prove_asm(file_name: &str, inputs: &[Bn254Field]) {
-    // read and compile PIL.
-
-    let contents = fs::read_to_string(file_name).unwrap();
-    let pil = pilgen::compile::<Bn254Field>(Some(file_name), &contents).unwrap_or_else(|err| {
-        eprintln!("Error parsing .asm file:");
-        err.output_to_stderr();
-        panic!();
-    });
-
-    let analyzed = pil_analyzer::analyze_string(&format!("{pil}"));
-
-    mock_prove(analyzed, inputs);
-}
-
-pub fn mock_prove(analyzed: pil_analyzer::Analyzed<Bn254Field>, inputs: &[Bn254Field]) {
-    // define how query information is retrieved.
-
-    let query_callback = |query: &str| -> Option<Bn254Field> {
-        let items = query.split(',').map(|s| s.trim()).collect::<Vec<_>>();
-        assert_eq!(items.len(), 2);
-        match items[0] {
-            "\"input\"" => {
-                let index = items[1].parse::<usize>().unwrap();
-                let value = inputs.get(index).cloned();
-                if let Some(value) = value {
-                    log::trace!("Input query: Index {index} -> {value}");
-                }
-                value
-            }
-            _ => None,
-        }
-    };
+pub fn mock_prove(file: &Path, dir: &Path) {
+    let analyzed: Analyzed<Bn254Field> = pil_analyzer::analyze(file);
 
     assert_eq!(
         polyexen::expr::get_field_p::<Fr>(),
@@ -50,48 +17,112 @@ pub fn mock_prove(analyzed: pil_analyzer::Analyzed<Bn254Field>, inputs: &[Bn254F
         "powdr modulus doesn't match halo2 modulus"
     );
 
-    let circuit = analyzed_to_circuit(&analyzed, Some(query_callback));
+    let fixed_columns: Vec<&str> = analyzed
+        .constant_polys_in_source_order()
+        .iter()
+        .map(|(poly, _)| poly.absolute_name.as_str())
+        .collect();
 
-    let k = 1 + f32::log2(circuit.plaf.info.num_rows as f32).ceil() as u32;
+    let witness_columns: Vec<&str> = analyzed
+        .committed_polys_in_source_order()
+        .iter()
+        .map(|(poly, _)| poly.absolute_name.as_str())
+        .collect();
+
+    let (fixed, fixed_degree) = read_polys_file(
+        &mut File::open(dir.join("constants").with_extension("bin")).unwrap(),
+        &fixed_columns,
+    );
+    let (witness, witness_degree) = read_polys_file(
+        &mut File::open(dir.join("commits").with_extension("bin")).unwrap(),
+        &witness_columns,
+    );
+
+    assert_eq!(fixed_degree, witness_degree);
+
+    mock_prove_ast(&analyzed, fixed, witness)
+}
+
+fn mock_prove_ast<T: FieldElement>(
+    pil: &Analyzed<T>,
+    fixed: Vec<(&str, Vec<T>)>,
+    witness: Vec<(&str, Vec<T>)>,
+) {
+    let circuit = analyzed_to_circuit(pil, fixed, witness);
+
+    // double the row count in order to make space for the cells introduced by the backend
+    // TODO: use a precise count of the extra rows needed to avoid using so many rows
+
+    let circuit_row_count_log = usize::BITS - circuit.plaf.info.num_rows.leading_zeros();
+
+    let expanded_row_count_log = circuit_row_count_log + 1;
 
     log::debug!("{}", PlafDisplayBaseTOML(&circuit.plaf));
 
-    /*
-        let inputs: Vec<_> = inputs
-            .iter()
-            .map(|n| {
-                Fr::from_bytes(
-                    &n.to_biguint()
-                        .unwrap()
-                        .to_bytes_le()
-                        .into_iter()
-                        .chain(std::iter::repeat(0))
-                        .take(32)
-                        .collect::<Vec<_>>()
-                        .try_into()
-                        .unwrap(),
-                )
-                .unwrap()
-            })
-            .chain(std::iter::repeat(Fr::zero()))
-            .take(MAX_PUBLIC_INPUTS)
-            .collect();
+    let inputs = vec![];
 
-    */
-
-    let mock_prover = MockProver::<Fr>::run(k, &circuit, vec![]).unwrap();
+    let mock_prover = MockProver::<Fr>::run(expanded_row_count_log, &circuit, inputs).unwrap();
     mock_prover.assert_satisfied();
 }
 
 #[cfg(test)]
 mod test {
+    use std::fs;
+
     use super::*;
+
+    fn mock_prove_asm(file_name: &str, inputs: &[Bn254Field]) {
+        // read and compile PIL.
+
+        let contents = fs::read_to_string(file_name).unwrap();
+        let pil = pilgen::compile::<Bn254Field>(Some(file_name), &contents).unwrap_or_else(|err| {
+            eprintln!("Error parsing .asm file:");
+            err.output_to_stderr();
+            panic!();
+        });
+
+        let query_callback = |query: &str| -> Option<Bn254Field> {
+            let items = query.split(',').map(|s| s.trim()).collect::<Vec<_>>();
+            match items[0] {
+                "\"input\"" => {
+                    assert_eq!(items.len(), 2);
+                    let index = items[1].parse::<usize>().unwrap();
+                    let value = inputs.get(index).cloned();
+                    if let Some(value) = value {
+                        log::trace!("Input query: Index {index} -> {value}");
+                    }
+                    value
+                }
+                "\"print\"" => {
+                    log::info!("Print: {}", items[1..].join(", "));
+                    Some(0.into())
+                }
+                "\"print_ch\"" => {
+                    print!("{}", items[1].parse::<u8>().unwrap() as char);
+                    Some(0.into())
+                }
+                _ => None,
+            }
+        };
+
+        let analyzed = pil_analyzer::analyze_string(&format!("{pil}"));
+
+        let (fixed, degree) = executor::constant_evaluator::generate(&analyzed);
+        let witness = executor::witgen::generate(&analyzed, degree, &fixed, Some(query_callback));
+
+        mock_prove_ast(&analyzed, fixed, witness);
+    }
 
     #[test]
     fn simple_pil_halo2() {
         let content = "namespace Global(8); pol fixed z = [0]*; pol witness a; a = 0;";
-        let analyzed = pil_analyzer::analyze_string(content);
-        super::mock_prove(analyzed, &vec![]);
+        let analyzed: Analyzed<Bn254Field> = pil_analyzer::analyze_string(content);
+        let (fixed, degree) = executor::constant_evaluator::generate(&analyzed);
+
+        let query_callback = |_: &str| -> Option<Bn254Field> { None };
+
+        let witness = executor::witgen::generate(&analyzed, degree, &fixed, Some(query_callback));
+        mock_prove_ast(&analyzed, fixed, witness);
     }
 
     #[test]

--- a/halo2/src/mock_prover.rs
+++ b/halo2/src/mock_prover.rs
@@ -1,0 +1,108 @@
+use std::fs;
+
+use polyexen::plaf::PlafDisplayBaseTOML;
+
+use super::circuit_builder::analyzed_to_circuit;
+use halo2_proofs::{dev::MockProver, halo2curves::bn256::Fr};
+use number::{BigInt, Bn254Field, FieldElement};
+
+// Follow dependency installation instructions from https://github.com/ed255/polyexen-demo
+
+//const MAX_PUBLIC_INPUTS: usize = 12;
+
+pub fn mock_prove_asm(file_name: &str, inputs: &[Bn254Field]) {
+    // read and compile PIL.
+
+    let contents = fs::read_to_string(file_name).unwrap();
+    let pil = pilgen::compile::<Bn254Field>(Some(file_name), &contents).unwrap_or_else(|err| {
+        eprintln!("Error parsing .asm file:");
+        err.output_to_stderr();
+        panic!();
+    });
+
+    let analyzed = pil_analyzer::analyze_string(&format!("{pil}"));
+
+    mock_prove(analyzed, inputs);
+}
+
+pub fn mock_prove(analyzed: pil_analyzer::Analyzed<Bn254Field>, inputs: &[Bn254Field]) {
+    // define how query information is retrieved.
+
+    let query_callback = |query: &str| -> Option<Bn254Field> {
+        let items = query.split(',').map(|s| s.trim()).collect::<Vec<_>>();
+        assert_eq!(items.len(), 2);
+        match items[0] {
+            "\"input\"" => {
+                let index = items[1].parse::<usize>().unwrap();
+                let value = inputs.get(index).cloned();
+                if let Some(value) = value {
+                    log::trace!("Input query: Index {index} -> {value}");
+                }
+                value
+            }
+            _ => None,
+        }
+    };
+
+    assert_eq!(
+        polyexen::expr::get_field_p::<Fr>(),
+        Bn254Field::modulus().to_arbitrary_integer(),
+        "powdr modulus doesn't match halo2 modulus"
+    );
+
+    let circuit = analyzed_to_circuit(&analyzed, Some(query_callback));
+
+    let k = 1 + f32::log2(circuit.plaf.info.num_rows as f32).ceil() as u32;
+
+    log::debug!("{}", PlafDisplayBaseTOML(&circuit.plaf));
+
+    /*
+        let inputs: Vec<_> = inputs
+            .iter()
+            .map(|n| {
+                Fr::from_bytes(
+                    &n.to_biguint()
+                        .unwrap()
+                        .to_bytes_le()
+                        .into_iter()
+                        .chain(std::iter::repeat(0))
+                        .take(32)
+                        .collect::<Vec<_>>()
+                        .try_into()
+                        .unwrap(),
+                )
+                .unwrap()
+            })
+            .chain(std::iter::repeat(Fr::zero()))
+            .take(MAX_PUBLIC_INPUTS)
+            .collect();
+
+    */
+
+    let mock_prover = MockProver::<Fr>::run(k, &circuit, vec![]).unwrap();
+    mock_prover.assert_satisfied();
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn simple_pil_halo2() {
+        let content = "namespace Global(8); pol fixed z = [0]*; pol witness a; a = 0;";
+        let analyzed = pil_analyzer::analyze_string(content);
+        super::mock_prove(analyzed, &vec![]);
+    }
+
+    #[test]
+    fn fibonacci() {
+        let inputs = [165, 5, 11, 22, 33, 44, 55].map(From::from);
+        mock_prove_asm("../test_data/asm/simple_sum.asm", &inputs);
+    }
+
+    #[test]
+    fn palindrome() {
+        let inputs = [3, 11, 22, 11].map(From::from);
+        mock_prove_asm("../test_data/asm/palindrome.asm", &inputs);
+    }
+}

--- a/number/src/lib.rs
+++ b/number/src/lib.rs
@@ -4,7 +4,10 @@
 mod macros;
 mod bn254;
 mod goldilocks;
+mod serialize;
 mod traits;
+
+pub use serialize::{read_polys_file, write_polys_file};
 
 pub use bn254::Bn254Field;
 pub use goldilocks::GoldilocksField;

--- a/number/src/macros.rs
+++ b/number/src/macros.rs
@@ -275,6 +275,16 @@ macro_rules! powdr_field {
             fn to_bytes_le(&self) -> Vec<u8> {
                 self.value.into_bigint().to_bytes_le()
             }
+
+            fn from_bytes_le(bytes: &[u8]) -> Self {
+                Self {
+                    value: <$ark_type as PrimeField>::BigInt::try_from(BigUint::from_bytes_le(
+                        bytes,
+                    ))
+                    .unwrap()
+                    .into(),
+                }
+            }
         }
 
         impl From<$ark_type> for $name {

--- a/number/src/serialize.rs
+++ b/number/src/serialize.rs
@@ -1,0 +1,77 @@
+use std::io::{Read, Write};
+
+use crate::{BigInt, DegreeType, FieldElement};
+
+fn ceil_div(num: usize, div: usize) -> usize {
+    (num + div - 1) / div
+}
+
+pub fn write_polys_file<T: FieldElement>(
+    file: &mut impl Write,
+    degree: DegreeType,
+    polys: &Vec<(&str, Vec<T>)>,
+) {
+    let width = ceil_div(T::modulus().to_arbitrary_integer().bits() as usize, 64) * 8;
+
+    for i in 0..degree as usize {
+        for (_name, constant) in polys {
+            let bytes = constant[i].to_bytes_le();
+            assert_eq!(bytes.len(), width);
+            file.write_all(&bytes).unwrap();
+        }
+    }
+}
+
+pub fn read_polys_file<'a, T: FieldElement>(
+    file: &mut impl Read,
+    columns: &[&'a str],
+) -> (Vec<(&'a str, Vec<T>)>, DegreeType) {
+    let width = ceil_div(T::modulus().to_arbitrary_integer().bits() as usize, 64) * 8;
+
+    let bytes_to_read = width * columns.len();
+
+    let mut result: Vec<(_, Vec<T>)> = columns.iter().map(|name| (*name, vec![])).collect();
+    let mut degree = 0;
+
+    loop {
+        let mut buf = vec![0u8; bytes_to_read];
+        match file.read_exact(&mut buf) {
+            Ok(()) => {}
+            Err(_) => return (result, degree),
+        }
+        degree += 1;
+        result
+            .iter_mut()
+            .zip(buf.chunks(width))
+            .for_each(|((_, values), bytes)| {
+                values.push(T::from_bytes_le(bytes));
+            });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::Bn254Field;
+    use std::io::Cursor;
+
+    use super::*;
+
+    #[test]
+    fn write_read() {
+        let mut buf: Vec<u8> = vec![];
+
+        let degree = 4;
+        let polys = vec![
+            ("a", vec![Bn254Field::from(0); degree]),
+            ("b", vec![Bn254Field::from(1); degree]),
+        ];
+
+        write_polys_file(&mut buf, degree as u64, &polys);
+        let (read_polys, read_degree) =
+            read_polys_file::<Bn254Field>(&mut Cursor::new(buf), &["a", "b"]);
+
+        assert_eq!(read_polys, polys);
+        assert_eq!(read_degree, degree as u64);
+    }
+}

--- a/number/src/traits.rs
+++ b/number/src/traits.rs
@@ -75,6 +75,8 @@ pub trait FieldElement:
 
     fn to_bytes_le(&self) -> Vec<u8>;
 
+    fn from_bytes_le(bytes: &[u8]) -> Self;
+
     fn from_str(s: &str) -> Self;
 
     fn from_str_radix(s: &str, radix: u32) -> Result<Self, String>;

--- a/pil_analyzer/src/lib.rs
+++ b/pil_analyzer/src/lib.rs
@@ -18,12 +18,14 @@ pub fn analyze_string<T: FieldElement>(contents: &str) -> Analyzed<T> {
     pil_analyzer::process_pil_file_contents(contents)
 }
 
+#[derive(Debug)]
 pub enum StatementIdentifier {
     Definition(String),
     PublicDeclaration(String),
     Identity(usize),
 }
 
+#[derive(Debug)]
 pub struct Analyzed<T> {
     /// Constants are not namespaced!
     pub constants: HashMap<String, T>,
@@ -109,6 +111,7 @@ impl Polynomial {
     }
 }
 
+#[derive(Debug)]
 pub enum FunctionValueDefinition<T> {
     Mapping(Expression<T>),
     Array(Vec<RepeatedArray<T>>),
@@ -116,6 +119,7 @@ pub enum FunctionValueDefinition<T> {
 }
 
 /// An array of elements that might be repeated (the whole list is repeated).
+#[derive(Debug)]
 pub struct RepeatedArray<T> {
     pub values: Vec<Expression<T>>,
     pub repetitions: DegreeType,
@@ -134,6 +138,7 @@ impl<T> RepeatedArray<T> {
     }
 }
 
+#[derive(Debug)]
 pub struct PublicDeclaration {
     pub id: u64,
     pub source: SourceRef,

--- a/pilgen/src/lib.rs
+++ b/pilgen/src/lib.rs
@@ -65,10 +65,6 @@ impl<T: FieldElement> ASMPILConverter<T> {
                 1024
             };
 
-            assert!(
-                degree.is_power_of_two(),
-                "Degree should be a power of two, found {degree}",
-            );
             self.pil.push(Statement::Namespace(
                 0,
                 "Assembly".to_string(),

--- a/powdr_cli/Cargo.toml
+++ b/powdr_cli/Cargo.toml
@@ -12,6 +12,7 @@ parser = { path = "../parser" }
 riscv = { path = "../riscv" }
 number = { path = "../number" }
 halo2 = { path = "../halo2" }
+strum = { version = "0.24.1", features = ["derive"] }
 
 [[bin]]
 name = "powdr"

--- a/powdr_cli/Cargo.toml
+++ b/powdr_cli/Cargo.toml
@@ -11,6 +11,7 @@ compiler = { path = "../compiler" }
 parser = { path = "../parser" }
 riscv = { path = "../riscv" }
 number = { path = "../number" }
+halo2 = { path = "../halo2" }
 
 [[bin]]
 name = "powdr"

--- a/powdr_cli/src/main.rs
+++ b/powdr_cli/src/main.rs
@@ -3,7 +3,7 @@
 use clap::{Parser, Subcommand};
 use env_logger::{Builder, Target};
 use log::LevelFilter;
-use number::{FieldElement, GoldilocksField};
+use number::{Bn254Field, FieldElement, GoldilocksField};
 use std::{fs, io::Write, path::Path};
 
 #[derive(Parser)]
@@ -83,6 +83,18 @@ enum Commands {
         force: bool,
     },
 
+    /// Apply the Halo2 workflow on an input file and prover values.
+    /// That means parsing, analysis, witness generation,
+    /// and Halo2 mock proving.
+    Halo2MockProver {
+        /// Input file
+        file: String,
+
+        /// Comma-separated list of free inputs (numbers).
+        #[arg(short, long)]
+        inputs: String,
+    },
+
     /// Parses and prints the PIL file on stdout.
     Reformat {
         /// Input file
@@ -156,6 +168,16 @@ fn main() {
                 Path::new(&output_directory),
                 force,
             );
+        }
+        Commands::Halo2MockProver { file, inputs } => {
+            let inputs: Vec<_> = inputs
+                .split(',')
+                .map(|x| x.trim())
+                .filter(|x| !x.is_empty())
+                .map(Bn254Field::from_str)
+                .collect();
+
+            halo2::mock_prove_asm(&file, &inputs);
         }
     }
 }

--- a/powdr_cli/src/util.rs
+++ b/powdr_cli/src/util.rs
@@ -1,0 +1,9 @@
+/// Create a clap parser for an enum which implements `strum::{EnumString, EnumVariantNames}`
+#[macro_export]
+macro_rules! clap_enum_variants {
+    ($e: ty) => {{
+        use clap::builder::TypedValueParser;
+        use strum::VariantNames;
+        clap::builder::PossibleValuesParser::new(<$e>::VARIANTS).map(|s| s.parse::<$e>().unwrap())
+    }};
+}


### PR DESCRIPTION
Extracted from the rest of https://github.com/chriseth/powdr/pull/102. The other PR got a bit too complicated to rebase onto main because of the amount of changes in the `main` branch and the merge commits into the feature branch.

The author credits are kept in this PR.

Notes from @Schaeff:
- the number of required extra rows is not trivial to calculate and seems to depend on the exact Halo2 configuration. Doubling the table size seems fine for this PR.
- This PR removes the wrapping behavior. This means that if this is merged, the first row is not constrained together with the last row. Moreover, witness generation does not use wrapping logic.
- This PR removes the requirement on the number of rows to be a power of two. This can be enforced by the backend instead: Halo2 just extends to the next power of two (if there is enough space) and say estark should throw.