### PR TITLE
Ad CLI `prove` and `setup` commands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "compiler",
     "pilgen",
     "halo2",
+    "backend",
 ]
 
 [patch."https://github.com/privacy-scaling-explorations/halo2.git"]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "backend"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+halo2 = { path = "../halo2" }
+pil_analyzer = { path = "../pil_analyzer" }
+number = { path = "../number" }
+strum = { version = "0.24.1", features = ["derive"] }

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,0 +1,66 @@
+use number::FieldElement;
+use pil_analyzer::Analyzed;
+use std::io;
+use strum::{Display, EnumString, EnumVariantNames};
+
+#[derive(Clone, EnumString, EnumVariantNames, Display)]
+pub enum Backend {
+    #[strum(serialize = "halo2")]
+    Halo2,
+    #[strum(serialize = "halo2-mock")]
+    Halo2Mock,
+}
+
+/// Create a proof for a given PIL, fixed column values and witness column values
+/// using the chosen backend.
+
+pub type Proof = Vec<u8>;
+pub type Params = Vec<u8>;
+
+pub trait ProverWithParams {
+    fn prove<T: FieldElement, R: io::Read>(
+        pil: &Analyzed<T>,
+        fixed: Vec<(&str, Vec<T>)>,
+        witness: Vec<(&str, Vec<T>)>,
+        params: R,
+    ) -> Option<Proof>;
+
+    fn generate_params<T: FieldElement>(size: usize) -> Params;
+}
+
+pub trait ProverWithoutParams {
+    fn prove<T: FieldElement>(
+        pil: &Analyzed<T>,
+        fixed: Vec<(&str, Vec<T>)>,
+        witness: Vec<(&str, Vec<T>)>,
+    ) -> Option<Proof>;
+}
+
+pub struct Halo2Backend;
+pub struct Halo2MockBackend;
+
+impl ProverWithParams for Halo2Backend {
+    fn prove<T: FieldElement, R: io::Read>(
+        pil: &Analyzed<T>,
+        fixed: Vec<(&str, Vec<T>)>,
+        witness: Vec<(&str, Vec<T>)>,
+        params: R,
+    ) -> Option<Proof> {
+        Some(halo2::prove_ast_read_params(pil, fixed, witness, params))
+    }
+
+    fn generate_params<T: FieldElement>(size: usize) -> Params {
+        halo2::generate_params::<T>(size)
+    }
+}
+
+impl ProverWithoutParams for Halo2MockBackend {
+    fn prove<T: FieldElement>(
+        pil: &Analyzed<T>,
+        fixed: Vec<(&str, Vec<T>)>,
+        witness: Vec<(&str, Vec<T>)>,
+    ) -> Option<Proof> {
+        halo2::mock_prove(pil, fixed, witness);
+        None
+    }
+}

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+backend = { path = "../backend" }
 itertools = "^0.10"
 log = "0.4.17"
 mktemp = "0.5.0"
@@ -14,4 +15,4 @@ executor = { path = "../executor" }
 pilgen = { path = "../pilgen" }
 pil_analyzer = { path = "../pil_analyzer" }
 halo2 = { path = "../halo2" }
-strum = { version = "0.24.1", features = ["derive"] }
+json = "^0.12"

--- a/compiler/src/backends.rs
+++ b/compiler/src/backends.rs
@@ -1,7 +1,0 @@
-use strum::{Display, EnumString, EnumVariantNames};
-
-#[derive(Clone, EnumString, EnumVariantNames, Display)]
-pub enum Backend {
-    #[strum(serialize = "halo2")]
-    Halo2,
-}

--- a/compiler/src/util.rs
+++ b/compiler/src/util.rs
@@ -1,0 +1,35 @@
+use number::{read_polys_file, DegreeType, FieldElement};
+use pil_analyzer::Analyzed;
+use std::{fs::File, path::Path};
+
+pub fn read_fixed<'a, T: FieldElement>(
+    pil: &'a Analyzed<T>,
+    dir: &Path,
+) -> (Vec<(&'a str, Vec<T>)>, DegreeType) {
+    let fixed_columns: Vec<&str> = pil
+        .constant_polys_in_source_order()
+        .iter()
+        .map(|(poly, _)| poly.absolute_name.as_str())
+        .collect();
+
+    read_polys_file(
+        &mut File::open(dir.join("constants").with_extension("bin")).unwrap(),
+        &fixed_columns,
+    )
+}
+
+pub fn read_witness<'a, T: FieldElement>(
+    pil: &'a Analyzed<T>,
+    dir: &Path,
+) -> (Vec<(&'a str, Vec<T>)>, DegreeType) {
+    let witness_columns: Vec<&str> = pil
+        .committed_polys_in_source_order()
+        .iter()
+        .map(|(poly, _)| poly.absolute_name.as_str())
+        .collect();
+
+    read_polys_file(
+        &mut File::open(dir.join("commits").with_extension("bin")).unwrap(),
+        &witness_columns,
+    )
+}

--- a/halo2/src/lib.rs
+++ b/halo2/src/lib.rs
@@ -4,4 +4,4 @@ pub(crate) mod mock_prover;
 pub(crate) mod prover;
 
 pub use mock_prover::mock_prove;
-pub use prover::prove_ast;
+pub use prover::*;

--- a/powdr_cli/Cargo.toml
+++ b/powdr_cli/Cargo.toml
@@ -12,6 +12,7 @@ parser = { path = "../parser" }
 riscv = { path = "../riscv" }
 number = { path = "../number" }
 halo2 = { path = "../halo2" }
+backend = { path = "../backend" }
 strum = { version = "0.24.1", features = ["derive"] }
 
 [[bin]]


### PR DESCRIPTION
A previously generate params file can be passed to a prove command also.