### PR TITLE
Heap placement hack

### DIFF
--- a/riscv/runtime/src/allocator.rs
+++ b/riscv/runtime/src/allocator.rs
@@ -8,9 +8,12 @@ use core::{
     ptr::{self, addr_of},
 };
 
+// Force C representation so that the large buffer is at the end.
+// This might avoid access to memory with large gaps.
+#[repr(C)]
 struct FixedMemoryAllocator<const SIZE: usize> {
-    mem_buffer: [u8; SIZE],
     next_available: Cell<usize>,
+    mem_buffer: [u8; SIZE],
 }
 
 impl<const SIZE: usize> FixedMemoryAllocator<SIZE> {
@@ -53,7 +56,7 @@ unsafe impl<const SIZE: usize> GlobalAlloc for FixedMemoryAllocator<SIZE> {
 }
 
 #[global_allocator]
-static mut GLOBAL: FixedMemoryAllocator<{ 0x2000 }> = FixedMemoryAllocator::new();
+static mut GLOBAL: FixedMemoryAllocator<{ 1024 * 1024 * 1024 }> = FixedMemoryAllocator::new();
 
 #[alloc_error_handler]
 fn alloc_error(layout: Layout) -> ! {

--- a/riscv/runtime/src/allocator.rs
+++ b/riscv/runtime/src/allocator.rs
@@ -53,7 +53,7 @@ unsafe impl<const SIZE: usize> GlobalAlloc for FixedMemoryAllocator<SIZE> {
 }
 
 #[global_allocator]
-static mut GLOBAL: FixedMemoryAllocator<{ 1024 * 1024 * 1024 }> = FixedMemoryAllocator::new();
+static mut GLOBAL: FixedMemoryAllocator<{ 0x2000 }> = FixedMemoryAllocator::new();
 
 #[alloc_error_handler]
 fn alloc_error(layout: Layout) -> ! {

--- a/riscv/src/compiler.rs
+++ b/riscv/src/compiler.rs
@@ -13,7 +13,7 @@ pub fn compile_riscv_asm(mut assemblies: BTreeMap<String, String>) -> String {
     // stack grows towards zero
     let stack_start = 0x10000;
     // data grows away from zero
-    let data_start = 0x20000;
+    let data_start = 0x10100;
 
     assert!(assemblies
         .insert("__runtime".to_string(), runtime().to_string())


### PR DESCRIPTION
Allows a large allocation heap by placing it last address-wise, avoiding a large address gap in the memory state machine when accessing stuff after the heap. Fixes issue #331.