### PR TITLE
point to our halo2 fork for shuffles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,9 @@ members = [
 [patch."https://github.com/privacy-scaling-explorations/halo2.git"]
 # TODO change back to this once the PR is merged
 #halo2_proofs = { git = "https://github.com/appliedzkp/halo2.git", rev = "d3746109d7d38be53afc8ddae8fdfaf1f02ad1d7" }
-halo2_proofs = { git = "https://github.com/kilic/halo2", branch = "shuffle" }
+halo2_proofs = { git = "https://github.com/powdr-org/halo2", branch = "kilic/shuffle" }
 
 [patch.crates-io]
 # TODO change back to this once the PR is merged
 #halo2_proofs = { git = "https://github.com/appliedzkp/halo2.git", rev = "d3746109d7d38be53afc8ddae8fdfaf1f02ad1d7" }
-halo2_proofs = { git = "https://github.com/kilic/halo2", branch = "shuffle" }
+halo2_proofs = { git = "https://github.com/powdr-org/halo2", branch = "kilic/shuffle" }


### PR DESCRIPTION
kilic force pushed their fork which is under development and doesn't compile atm, so I forked their halo2 repo with the shuffles version that was working before