### PR TITLE
Generalize assembly handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "ast",
     "analysis",
     "linker",
+    "asm_utils"
 ]
 
 [patch."https://github.com/privacy-scaling-explorations/halo2.git"]

--- a/asm_utils/Cargo.toml
+++ b/asm_utils/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "asm_utils"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+itertools = "^0.10"

--- a/asm_utils/src/ast.rs
+++ b/asm_utils/src/ast.rs
@@ -1,0 +1,222 @@
+//! Common AST for the frontend architecture inputs.
+
+use std::fmt::{self, Display};
+
+#[derive(Clone)]
+pub enum Statement<R: Register, F: FunctionOpKind> {
+    Label(String),
+    Directive(String, Vec<Argument<R, F>>),
+    Instruction(String, Vec<Argument<R, F>>),
+}
+
+#[derive(Clone)]
+pub enum Argument<R: Register, F: FunctionOpKind> {
+    Register(R),
+    RegOffset(R, Expression<F>),
+    StringLiteral(Vec<u8>),
+    Expression(Expression<F>),
+}
+
+impl<R: Register, F: FunctionOpKind> Argument<R, F> {
+    pub fn post_visit_expressions_mut(&mut self, f: &mut impl FnMut(&mut Expression<F>)) {
+        match self {
+            Argument::Register(_) | Argument::StringLiteral(_) => (),
+            Argument::RegOffset(_, expr) | Argument::Expression(expr) => {
+                expr.post_visit_mut(f);
+            }
+        }
+    }
+
+    pub fn post_visit_expressions<'a>(&'a self, f: &mut impl FnMut(&'a Expression<F>)) {
+        match self {
+            Argument::Register(_) | Argument::StringLiteral(_) => (),
+            Argument::RegOffset(_, expr) | Argument::Expression(expr) => {
+                expr.post_visit(f);
+            }
+        }
+    }
+}
+
+pub trait Register: Display {}
+
+#[derive(Clone, Copy)]
+pub enum UnaryOpKind {
+    Negation,
+}
+
+impl Display for UnaryOpKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            UnaryOpKind::Negation => write!(f, "-"),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub enum BinaryOpKind {
+    Or,
+    Xor,
+    And,
+    LeftShift,
+    RightShift,
+    Add,
+    Sub,
+    Mul,
+    Div,
+    Mod,
+}
+
+pub trait FunctionOpKind: Display {}
+
+#[derive(Clone)]
+pub enum Expression<F> {
+    Number(i64),
+    Symbol(String),
+    UnaryOp(UnaryOpKind, Box<Expression<F>>),
+    BinaryOp(BinaryOpKind, Box<[Expression<F>; 2]>),
+    FunctionOp(F, Box<Expression<F>>),
+}
+
+impl<F> Expression<F> {
+    fn post_visit<'a>(&'a self, f: &mut impl FnMut(&'a Expression<F>)) {
+        match self {
+            Expression::Number(_) => {}
+            Expression::Symbol(_) => {}
+            Expression::UnaryOp(_, subexpr) => {
+                Self::post_visit(subexpr, f);
+            }
+            Expression::BinaryOp(_, subexprs) => {
+                subexprs.iter().for_each(|subexpr| {
+                    Self::post_visit(subexpr, f);
+                });
+            }
+            Expression::FunctionOp(_, subexpr) => {
+                Self::post_visit(subexpr, f);
+            }
+        }
+        f(self);
+    }
+
+    fn post_visit_mut(&mut self, f: &mut impl FnMut(&mut Expression<F>)) {
+        match self {
+            Expression::Number(_) => {}
+            Expression::Symbol(_) => {}
+            Expression::UnaryOp(_, subexpr) => {
+                Self::post_visit_mut(subexpr, f);
+            }
+            Expression::BinaryOp(_, subexprs) => {
+                subexprs.iter_mut().for_each(|subexpr| {
+                    Self::post_visit_mut(subexpr, f);
+                });
+            }
+            Expression::FunctionOp(_, subexpr) => {
+                Self::post_visit_mut(subexpr, f);
+            }
+        }
+        f(self);
+    }
+}
+
+pub fn new_unary_op<F: FunctionOpKind>(op: UnaryOpKind, v: Expression<F>) -> Expression<F> {
+    Expression::UnaryOp(op, Box::new(v))
+}
+
+pub fn new_binary_op<F: FunctionOpKind>(
+    op: BinaryOpKind,
+    l: Expression<F>,
+    r: Expression<F>,
+) -> Expression<F> {
+    Expression::BinaryOp(op, Box::new([l, r]))
+}
+
+pub fn new_function_op<F: FunctionOpKind>(op: F, v: Expression<F>) -> Expression<F> {
+    Expression::FunctionOp(op, Box::new(v))
+}
+
+impl<R: Register, F: FunctionOpKind> Display for Statement<R, F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Statement::Label(l) => writeln!(f, "{l}:"),
+            Statement::Directive(d, args) => writeln!(f, "  {d} {}", format_arguments(args)),
+            Statement::Instruction(i, args) => writeln!(f, "  {i} {}", format_arguments(args)),
+        }
+    }
+}
+
+impl<R: Register, F: FunctionOpKind> Display for Argument<R, F> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Argument::Register(r) => write!(f, "{r}"),
+            Argument::RegOffset(reg, off) => write!(f, "{off}({reg})"),
+            Argument::StringLiteral(lit) => write!(f, "\"{}\"", String::from_utf8_lossy(lit)),
+            Argument::Expression(expr) => write!(f, "{expr}"),
+        }
+    }
+}
+
+impl<F: FunctionOpKind> Display for Expression<F> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Expression::Number(n) => write!(f, "{n}"),
+            Expression::Symbol(sym) => write!(f, "{sym}"),
+            Expression::UnaryOp(kind, expr) => write!(f, "({}{})", kind, expr),
+            Expression::BinaryOp(op, args) => {
+                let symbol = match op {
+                    BinaryOpKind::Or => "|",
+                    BinaryOpKind::Xor => "^",
+                    BinaryOpKind::And => "&",
+                    BinaryOpKind::LeftShift => "<<",
+                    BinaryOpKind::RightShift => ">>",
+                    BinaryOpKind::Add => "+",
+                    BinaryOpKind::Sub => "-",
+                    BinaryOpKind::Mul => "*",
+                    BinaryOpKind::Div => "/",
+                    BinaryOpKind::Mod => "%",
+                };
+                write!(f, "({} {symbol} {})", args[0], args[1])
+            }
+            Expression::FunctionOp(kind, expr) => write!(f, "{}({})", kind, expr),
+        }
+    }
+}
+
+fn format_arguments<R: Register, F: FunctionOpKind>(args: &[Argument<R, F>]) -> String {
+    args.iter()
+        .map(|a| format!("{a}"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Parse an escaped string - used in the grammar.
+pub fn unescape_string(s: &str) -> Vec<u8> {
+    assert!(s.len() >= 2);
+    assert!(s.starts_with('"') && s.ends_with('"'));
+    let mut chars = s[1..s.len() - 1].chars();
+    let mut result = vec![];
+    while let Some(c) = chars.next() {
+        result.push(if c == '\\' {
+            let next = chars.next().unwrap();
+            if next.is_ascii_digit() {
+                // octal number.
+                let n = next as u8 - b'0';
+                let nn = chars.next().unwrap() as u8 - b'0';
+                let nnn = chars.next().unwrap() as u8 - b'0';
+                nnn + nn * 8 + n * 64
+            } else if next == 'x' {
+                todo!("Parse hex digit");
+            } else {
+                (match next {
+                    'n' => '\n',
+                    'r' => '\r',
+                    't' => '\t',
+                    'b' => 8 as char,
+                    'f' => 12 as char,
+                    other => other,
+                }) as u8
+            }
+        } else {
+            c as u8
+        })
+    }
+    result
+}

--- a/asm_utils/src/compiler.rs
+++ b/asm_utils/src/compiler.rs
@@ -1,0 +1,45 @@
+use std::collections::BTreeMap;
+
+use crate::ast::{Argument, Expression, FunctionOpKind, Register};
+
+pub trait Compiler {
+    fn compile(assemblies: BTreeMap<String, String>) -> String;
+}
+
+pub fn next_multiple_of_four(x: usize) -> usize {
+    ((x + 3) / 4) * 4
+}
+
+pub fn quote(s: &str) -> String {
+    // TODO more things to quote
+    format!("\"{}\"", s.replace('\\', "\\\\").replace('\"', "\\\""))
+}
+
+pub fn escape_label(l: &str) -> String {
+    // TODO make this proper
+    l.replace('.', "_dot_").replace('/', "_slash_")
+}
+
+pub fn argument_to_escaped_symbol<R: Register, F: FunctionOpKind>(x: &Argument<R, F>) -> String {
+    if let Argument::Expression(Expression::Symbol(symb)) = x {
+        escape_label(symb)
+    } else {
+        panic!("Expected a symbol, got {x}");
+    }
+}
+
+pub fn argument_to_number<R: Register, F: FunctionOpKind>(x: &Argument<R, F>) -> u32 {
+    if let Argument::Expression(expr) = x {
+        expression_to_number(expr)
+    } else {
+        panic!("Expected numeric expression, got {x}")
+    }
+}
+
+pub fn expression_to_number<F: FunctionOpKind>(expr: &Expression<F>) -> u32 {
+    if let Expression::Number(n) = expr {
+        *n as u32
+    } else {
+        panic!("Constant expression could not be fully resolved to a number during preprocessing: {expr}");
+    }
+}

--- a/asm_utils/src/data_parser.rs
+++ b/asm_utils/src/data_parser.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use crate::parser::{Argument, Expression, Statement};
+use crate::ast::{Argument, Expression, FunctionOpKind, Register, Statement};
 
 pub enum DataValue {
     Direct(Vec<u8>),
@@ -22,8 +22,8 @@ impl DataValue {
 /// Extract all data objects from the list of statements.
 /// Returns the named data objects themselves and a vector of the names
 /// in the order in which they occur in the statements.
-pub fn extract_data_objects(
-    statements: &[Statement],
+pub fn extract_data_objects<R: Register, F: FunctionOpKind>(
+    statements: &[Statement<R, F>],
 ) -> (BTreeMap<String, Vec<DataValue>>, Vec<String>) {
     let mut object_order = vec![];
     let mut current_label = None;
@@ -74,7 +74,10 @@ pub fn extract_data_objects(
     (objects, object_order)
 }
 
-fn extract_data_value(directive: &str, arguments: &[Argument]) -> Vec<DataValue> {
+fn extract_data_value<R: Register, F: FunctionOpKind>(
+    directive: &str,
+    arguments: &[Argument<R, F>],
+) -> Vec<DataValue> {
     match (directive, arguments) {
         (
             ".zero",

--- a/asm_utils/src/lib.rs
+++ b/asm_utils/src/lib.rs
@@ -1,0 +1,7 @@
+//! Common crate for generalized assembly handling.
+
+pub mod ast;
+pub mod compiler;
+pub mod data_parser;
+pub mod parser;
+pub mod reachability;

--- a/asm_utils/src/parser.rs
+++ b/asm_utils/src/parser.rs
@@ -1,0 +1,17 @@
+use crate::ast::{FunctionOpKind, Register, Statement};
+
+pub fn parse_asm<R: Register, F: FunctionOpKind, P: Parser<R, F>>(
+    parser: P,
+    input: &str,
+) -> Vec<Statement<R, F>> {
+    input
+        .split('\n')
+        .map(|l| l.trim())
+        .filter(|l| !l.is_empty())
+        .flat_map(|line| parser.parse(line).unwrap())
+        .collect()
+}
+
+pub trait Parser<R: Register, F: FunctionOpKind> {
+    fn parse(&self, input: &str) -> Result<Vec<Statement<R, F>>, String>;
+}

--- a/riscv/Cargo.toml
+++ b/riscv/Cargo.toml
@@ -13,6 +13,7 @@ walkdir = "2.3.3"
 number = { path = "../number" }
 compiler = { path = "../compiler" }
 parser_util = { path = "../parser_util" }
+asm_utils = { path = "../asm_utils" }
 # This is only here to work around https://github.com/lalrpop/lalrpop/issues/750
 # It should be removed once that workaround is no longer needed.
 regex-syntax = { version = "0.6", default_features = false, features = ["unicode"] }

--- a/riscv/src/disambiguator.rs
+++ b/riscv/src/disambiguator.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use itertools::Itertools;
 
-use crate::parser::{Argument, Expression, Statement};
+use crate::{Argument, Expression, Statement};
 
 /// Disambiguates the collection of assembly files and concatenates it to a single list of statements.
 /// Also disambiguates file ids (debugging information) and returns a list of all files with new IDs.

--- a/riscv/src/lib.rs
+++ b/riscv/src/lib.rs
@@ -3,17 +3,22 @@
 use std::{collections::BTreeMap, path::Path, process::Command};
 
 use ::compiler::{compile_asm_string, Backend};
+use asm_utils::compiler::Compiler;
 use mktemp::Temp;
 use std::fs;
 use walkdir::WalkDir;
 
 use number::FieldElement;
 
+use crate::compiler::{FunctionKind, Register};
+
 pub mod compiler;
-mod data_parser;
 mod disambiguator;
 pub mod parser;
-mod reachability;
+
+type Statement = asm_utils::ast::Statement<Register, FunctionKind>;
+type Argument = asm_utils::ast::Argument<Register, FunctionKind>;
+type Expression = asm_utils::ast::Expression<FunctionKind>;
 
 /// Compiles a rust file all the way down to PIL and generates
 /// fixed and witness columns.
@@ -85,7 +90,7 @@ pub fn compile_riscv_asm_bundle<T: FieldElement>(
         return;
     }
 
-    let powdr_asm = compiler::compile_riscv_asm(riscv_asm_files);
+    let powdr_asm = compiler::Risc::compile(riscv_asm_files);
 
     fs::write(powdr_asm_file_name.clone(), &powdr_asm).unwrap();
     log::info!("Wrote {}", powdr_asm_file_name.to_str().unwrap());

--- a/riscv/src/parser.rs
+++ b/riscv/src/parser.rs
@@ -1,7 +1,9 @@
-use std::fmt::{self, Display};
-
 use lalrpop_util::*;
 
+use crate::{
+    compiler::{FunctionKind, Register},
+    Statement,
+};
 use parser_util::handle_parse_error;
 
 lalrpop_mod!(
@@ -10,222 +12,23 @@ lalrpop_mod!(
     "/riscv_asm.rs"
 );
 
-#[derive(Clone)]
-pub enum Statement {
-    Label(String),
-    Directive(String, Vec<Argument>),
-    Instruction(String, Vec<Argument>),
+pub struct RiscParser {
+    parser: riscv_asm::StatementsParser,
 }
 
-#[derive(Clone)]
-pub enum Argument {
-    Register(Register),
-    RegOffset(Register, Expression),
-    StringLiteral(Vec<u8>),
-    Expression(Expression),
-}
-
-impl Argument {
-    pub(crate) fn post_visit_expressions_mut(&mut self, f: &mut impl FnMut(&mut Expression)) {
-        match self {
-            Argument::Register(_) | Argument::StringLiteral(_) => (),
-            Argument::RegOffset(_, expr) | Argument::Expression(expr) => {
-                expr.post_visit_mut(f);
-            }
-        }
-    }
-
-    pub(crate) fn post_visit_expressions<'a>(&'a self, f: &mut impl FnMut(&'a Expression)) {
-        match self {
-            Argument::Register(_) | Argument::StringLiteral(_) => (),
-            Argument::RegOffset(_, expr) | Argument::Expression(expr) => {
-                expr.post_visit(f);
-            }
+impl Default for RiscParser {
+    fn default() -> Self {
+        Self {
+            parser: riscv_asm::StatementsParser::new(),
         }
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub struct Register(u8);
-
-impl Register {
-    pub fn is_zero(&self) -> bool {
-        self.0 == 0
-    }
-}
-
-#[derive(Clone, Copy)]
-pub enum UnaryOpKind {
-    HiDataRef,
-    LoDataRef,
-    Negation,
-}
-
-#[derive(Clone, Copy)]
-pub enum BinaryOpKind {
-    Or,
-    Xor,
-    And,
-    LeftShift,
-    RightShift,
-    Add,
-    Sub,
-    Mul,
-    Div,
-    Mod,
-}
-
-#[derive(Clone)]
-pub enum Expression {
-    Number(i64),
-    Symbol(String),
-    UnaryOp(UnaryOpKind, Box<[Expression]>),
-    BinaryOp(BinaryOpKind, Box<[Expression; 2]>),
-}
-
-impl Expression {
-    fn post_visit<'a>(&'a self, f: &mut impl FnMut(&'a Expression)) {
-        match self {
-            Expression::UnaryOp(_, subexpr) => subexpr.iter(),
-            Expression::BinaryOp(_, subexprs) => subexprs.iter(),
-            _ => [].iter(),
-        }
-        .for_each(|subexpr| {
-            Self::post_visit(subexpr, f);
-        });
-        f(self);
-    }
-
-    fn post_visit_mut(&mut self, f: &mut impl FnMut(&mut Expression)) {
-        match self {
-            Expression::UnaryOp(_, subexpr) => subexpr.iter_mut(),
-            Expression::BinaryOp(_, subexprs) => subexprs.iter_mut(),
-            _ => [].iter_mut(),
-        }
-        .for_each(|subexpr| {
-            Self::post_visit_mut(subexpr, f);
-        });
-        f(self);
-    }
-}
-
-fn new_unary_op(op: UnaryOpKind, v: Expression) -> Expression {
-    Expression::UnaryOp(op, Box::new([v]))
-}
-
-fn new_binary_op(op: BinaryOpKind, l: Expression, r: Expression) -> Expression {
-    Expression::BinaryOp(op, Box::new([l, r]))
-}
-
-impl Display for Statement {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Statement::Label(l) => writeln!(f, "{l}:"),
-            Statement::Directive(d, args) => writeln!(f, "  {d} {}", format_arguments(args)),
-            Statement::Instruction(i, args) => writeln!(f, "  {i} {}", format_arguments(args)),
-        }
-    }
-}
-
-impl Display for Argument {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Argument::Register(r) => write!(f, "{r}"),
-            Argument::RegOffset(reg, off) => write!(f, "{off}({reg})"),
-            Argument::StringLiteral(lit) => write!(f, "\"{}\"", String::from_utf8_lossy(lit)),
-            Argument::Expression(expr) => write!(f, "{expr}"),
-        }
-    }
-}
-
-impl Display for Expression {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Expression::Number(n) => write!(f, "{n}"),
-            Expression::Symbol(sym) => write!(f, "{sym}"),
-            Expression::UnaryOp(UnaryOpKind::Negation, expr) => write!(f, "(-{})", expr[0]),
-            Expression::UnaryOp(UnaryOpKind::HiDataRef, expr) => write!(f, "%hi({})", expr[0]),
-            Expression::UnaryOp(UnaryOpKind::LoDataRef, expr) => write!(f, "%lo({})", expr[0]),
-            Expression::BinaryOp(op, args) => {
-                let symbol = match op {
-                    BinaryOpKind::Or => "|",
-                    BinaryOpKind::Xor => "^",
-                    BinaryOpKind::And => "&",
-                    BinaryOpKind::LeftShift => "<<",
-                    BinaryOpKind::RightShift => ">>",
-                    BinaryOpKind::Add => "+",
-                    BinaryOpKind::Sub => "-",
-                    BinaryOpKind::Mul => "*",
-                    BinaryOpKind::Div => "/",
-                    BinaryOpKind::Mod => "%",
-                };
-                write!(f, "({} {symbol} {})", args[0], args[1])
-            }
-        }
-    }
-}
-
-fn format_arguments(args: &[Argument]) -> String {
-    args.iter()
-        .map(|a| format!("{a}"))
-        .collect::<Vec<_>>()
-        .join(", ")
-}
-
-impl Display for Register {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "x{}", self.0)
-    }
-}
-
-pub fn parse_asm(input: &str) -> Vec<Statement> {
-    let parser = riscv_asm::StatementsParser::new();
-    input
-        .split('\n')
-        .map(|l| l.trim())
-        .filter(|l| !l.is_empty())
-        .flat_map(|line| {
-            parser
-                .parse(line)
-                .map_err(|err| {
-                    handle_parse_error(err, None, line).output_to_stderr();
-                    panic!("RISCV assembly parse error");
-                })
-                .unwrap()
-        })
-        .collect()
-}
-
-/// Parse an escaped string - used in the grammar.
-fn unescape_string(s: &str) -> Vec<u8> {
-    assert!(s.len() >= 2);
-    assert!(s.starts_with('"') && s.ends_with('"'));
-    let mut chars = s[1..s.len() - 1].chars();
-    let mut result = vec![];
-    while let Some(c) = chars.next() {
-        result.push(if c == '\\' {
-            let next = chars.next().unwrap();
-            if next.is_ascii_digit() {
-                // octal number.
-                let n = next as u8 - b'0';
-                let nn = chars.next().unwrap() as u8 - b'0';
-                let nnn = chars.next().unwrap() as u8 - b'0';
-                nnn + nn * 8 + n * 64
-            } else if next == 'x' {
-                todo!("Parse hex digit");
-            } else {
-                (match next {
-                    'n' => '\n',
-                    'r' => '\r',
-                    't' => '\t',
-                    'b' => 8 as char,
-                    'f' => 12 as char,
-                    other => other,
-                }) as u8
-            }
-        } else {
-            c as u8
+impl asm_utils::parser::Parser<Register, FunctionKind> for RiscParser {
+    fn parse(&self, input: &str) -> Result<Vec<Statement>, String> {
+        self.parser.parse(input).map_err(|err| {
+            handle_parse_error(err, None, input).output_to_stderr();
+            panic!("RISCV assembly parse error");
         })
     }
-    result
 }

--- a/riscv/src/riscv_asm.lalrpop
+++ b/riscv/src/riscv_asm.lalrpop
@@ -1,5 +1,7 @@
 use std::str::FromStr;
-use crate::parser::{Statement, Argument, Register, Expression, unescape_string, BinaryOpKind as BOp, UnaryOpKind as UOp, new_binary_op as bin_op, new_unary_op as un_op};
+use asm_utils::ast::{unescape_string, BinaryOpKind as BOp, UnaryOpKind as UOp,
+    new_binary_op as bin_op, new_unary_op as un_op, new_function_op as fn_op};
+use crate::{Argument, Register, Statement, FunctionKind as FOp, Expression};
 
 grammar;
 
@@ -75,22 +77,22 @@ Argument: Argument = {
 }
 
 Register: Register = {
-    r"x[0-9]" => Register(<>[1..].parse().unwrap()),
-    r"x1[0-9]" => Register(<>[1..].parse().unwrap()),
-    r"x2[0-9]" => Register(<>[1..].parse().unwrap()),
-    r"x3[0-1]" => Register(<>[1..].parse().unwrap()),
-    "zero" => Register(0),
-    "ra" => Register(1),
-    "sp" => Register(2),
-    "gp" => Register(3),
-    "tp" => Register(4),
-    r"a[0-7]" => Register(10 + <>[1..].parse::<u8>().unwrap()),
-    "fp" => Register(8),
-    r"s[0-1]" => Register(8 + <>[1..].parse::<u8>().unwrap()),
-    r"s[2-9]" => Register(16 + <>[1..].parse::<u8>().unwrap()),
-    r"s1[0-1]" => Register(16 + <>[1..].parse::<u8>().unwrap()),
-    r"t[0-2]" => Register(5 + <>[1..].parse::<u8>().unwrap()),
-    r"t[3-6]" => Register(25 + <>[1..].parse::<u8>().unwrap()),
+    r"x[0-9]" => Register::new(<>[1..].parse().unwrap()),
+    r"x1[0-9]" => Register::new(<>[1..].parse().unwrap()),
+    r"x2[0-9]" => Register::new(<>[1..].parse().unwrap()),
+    r"x3[0-1]" => Register::new(<>[1..].parse().unwrap()),
+    "zero" => Register::new(0),
+    "ra" => Register::new(1),
+    "sp" => Register::new(2),
+    "gp" => Register::new(3),
+    "tp" => Register::new(4),
+    r"a[0-7]" => Register::new(10 + <>[1..].parse::<u8>().unwrap()),
+    "fp" => Register::new(8),
+    r"s[0-1]" => Register::new(8 + <>[1..].parse::<u8>().unwrap()),
+    r"s[2-9]" => Register::new(16 + <>[1..].parse::<u8>().unwrap()),
+    r"s1[0-1]" => Register::new(16 + <>[1..].parse::<u8>().unwrap()),
+    r"t[0-2]" => Register::new(5 + <>[1..].parse::<u8>().unwrap()),
+    r"t[3-6]" => Register::new(25 + <>[1..].parse::<u8>().unwrap()),
 }
 
 OffsetRegister: Argument = {
@@ -144,8 +146,8 @@ ExprUnary: Expression = {
 ExprTerm: Expression = {
     Number => Expression::Number(<>),
     "(" <Expression> ")" => <>,
-    "%hi(" <Expression> ")" => un_op(UOp::HiDataRef, <>),
-    "%lo(" <Expression> ")" => un_op(UOp::LoDataRef, <>),
+    "%hi(" <Expression> ")" => fn_op(FOp::HiDataRef, <>),
+    "%lo(" <Expression> ")" => fn_op(FOp::LoDataRef, <>),
     Symbol => Expression::Symbol(<>)
 }
 

--- a/riscv/tests/instructions.rs
+++ b/riscv/tests/instructions.rs
@@ -1,12 +1,13 @@
 mod instruction_tests {
+    use asm_utils::compiler::Compiler;
     use compiler::verify_asm_string;
     use number::GoldilocksField;
-    use riscv::compiler::compile_riscv_asm;
+    use riscv::compiler::Risc;
     use test_log::test;
 
     fn run_instruction_test(assembly: &str, name: &str) {
         // TODO Should we create one powdr asm from all tests or keep them separate?
-        let powdr_asm = compile_riscv_asm([(name.to_string(), assembly.to_string())].into());
+        let powdr_asm = Risc::compile([(name.to_string(), assembly.to_string())].into());
 
         verify_asm_string::<GoldilocksField>(&format!("{name}.asm"), &powdr_asm, vec![]);
     }

--- a/riscv/tests/riscv.rs
+++ b/riscv/tests/riscv.rs
@@ -1,3 +1,4 @@
+use asm_utils::compiler::Compiler;
 use compiler::verify_asm_string;
 use number::GoldilocksField;
 use test_log::test;
@@ -95,7 +96,7 @@ fn test_print() {
 
 fn verify_file(case: &str, inputs: Vec<GoldilocksField>) {
     let riscv_asm = riscv::compile_rust_to_riscv_asm(&format!("tests/riscv_data/{case}"));
-    let powdr_asm = riscv::compiler::compile_riscv_asm(riscv_asm);
+    let powdr_asm = riscv::compiler::Risc::compile(riscv_asm);
 
     verify_asm_string(&format!("{case}.asm"), &powdr_asm, inputs);
 }
@@ -103,7 +104,7 @@ fn verify_file(case: &str, inputs: Vec<GoldilocksField>) {
 fn verify_crate(case: &str, inputs: Vec<GoldilocksField>) {
     let riscv_asm =
         riscv::compile_rust_crate_to_riscv_asm(&format!("tests/riscv_data/{case}/Cargo.toml"));
-    let powdr_asm = riscv::compiler::compile_riscv_asm(riscv_asm);
+    let powdr_asm = riscv::compiler::Risc::compile(riscv_asm);
 
     verify_asm_string(&format!("{case}.asm"), &powdr_asm, inputs);
 }


### PR DESCRIPTION
This PR generalizes assembly handling to accommodate for additional architectures, using the existing riscv pipeline as the base. General assembly handling code is moved to the new `frontend-vm` crate and the elements specific to riscv are kept in the `riscv` crate.

closes #353