### PR TITLE
Add logging to witness generation code

### DIFF
--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -225,6 +225,8 @@ pub fn inputs_to_query_callback<T: FieldElement>(inputs: Vec<T>) -> impl Fn(&str
                 let value = inputs.get(index).cloned();
                 if let Some(value) = value {
                     log::trace!("Input query: Index {index} -> {value}");
+                } else {
+                    log::warn!("Not enough inputs provided! Index {index} out of bounds")
                 }
                 value
             }

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 itertools = "^0.10"
-log = "0.4.17"
+log = { version = "0.4.17", features = ["release_max_level_debug"] }
 number = { path = "../number" }
 parser_util = { path = "../parser_util" }
 pil_analyzer = { path = "../pil_analyzer" }

--- a/executor/src/witgen/eval_result.rs
+++ b/executor/src/witgen/eval_result.rs
@@ -142,10 +142,10 @@ where
 
 /// Result of evaluating an expression / lookup.
 /// New assignments or constraints for witness columns identified by an ID.
-pub type EvalResult<'a, T, K = &'a PolynomialReference> = Result<EvalValue<K, T>, EvalError>;
+pub type EvalResult<'a, T, K = &'a PolynomialReference> = Result<EvalValue<K, T>, EvalError<T>>;
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum EvalError {
+pub enum EvalError<T: FieldElement> {
     /// We ran out of rows
     RowsExhausted,
     /// A constraint that cannot be satisfied (i.e. 2 = 1).
@@ -155,19 +155,19 @@ pub enum EvalError {
     /// A division pattern was recognized but the solution does not satisfy the range constraints.
     InvalidDivision,
     // Fixed lookup failed
-    FixedLookupFailed(String),
+    FixedLookupFailed(Vec<(String, T)>),
     Generic(String),
-    Multiple(Vec<EvalError>),
+    Multiple(Vec<EvalError<T>>),
 }
 
-impl From<String> for EvalError {
+impl<T: FieldElement> From<String> for EvalError<T> {
     fn from(value: String) -> Self {
         Self::Generic(value)
     }
 }
 
-impl EvalError {
-    pub fn combine(self, other: EvalError) -> EvalError {
+impl<T: FieldElement> EvalError<T> {
+    pub fn combine(self, other: EvalError<T>) -> EvalError<T> {
         match (self, other) {
             (EvalError::Multiple(l), EvalError::Multiple(r)) => {
                 EvalError::Multiple(l.into_iter().chain(r).collect())
@@ -180,7 +180,7 @@ impl EvalError {
     }
 }
 
-impl fmt::Display for EvalError {
+impl<T: FieldElement> fmt::Display for EvalError<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             EvalError::ConstraintUnsatisfiable(e) => {
@@ -199,10 +199,17 @@ impl fmt::Display for EvalError {
                 write!(f, "A division pattern was recognized but the range constrainst are conflicting with the solution.",)
             }
             EvalError::RowsExhausted => write!(f, "Table rows exhausted"),
-            EvalError::FixedLookupFailed(query) => write!(
-                f,
-                "Lookup into fixed columns failed: no match for query: {query}"
-            ),
+            EvalError::FixedLookupFailed(input_assignment) => {
+                let query = input_assignment
+                    .iter()
+                    .map(|(poly_name, v)| format!("{} = {}", poly_name, v))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                write!(
+                    f,
+                    "Lookup into fixed columns failed: no match for query: {query}"
+                )
+            }
             EvalError::Generic(s) => write!(f, "{s}"),
         }
     }

--- a/executor/src/witgen/eval_result.rs
+++ b/executor/src/witgen/eval_result.rs
@@ -155,7 +155,7 @@ pub enum EvalError {
     /// A division pattern was recognized but the solution does not satisfy the range constraints.
     InvalidDivision,
     // Fixed lookup failed
-    FixedLookupFailed,
+    FixedLookupFailed(String),
     Generic(String),
     Multiple(Vec<EvalError>),
 }
@@ -199,7 +199,10 @@ impl fmt::Display for EvalError {
                 write!(f, "A division pattern was recognized but the range constrainst are conflicting with the solution.",)
             }
             EvalError::RowsExhausted => write!(f, "Table rows exhausted"),
-            EvalError::FixedLookupFailed => write!(f, "Lookup into fixed columns failed: no match"),
+            EvalError::FixedLookupFailed(query) => write!(
+                f,
+                "Lookup into fixed columns failed: no match for query: {query}"
+            ),
             EvalError::Generic(s) => write!(f, "{s}"),
         }
     }

--- a/executor/src/witgen/machines/block_machine.rs
+++ b/executor/src/witgen/machines/block_machine.rs
@@ -231,7 +231,7 @@ impl<'a, T: FieldElement> ChangeLogger<'a, T> {
 
 impl<T: FieldElement> BlockMachine<T> {
     /// Extends the data with a new block.
-    fn append_new_block(&mut self, max_len: DegreeType) -> Result<(), EvalError> {
+    fn append_new_block(&mut self, max_len: DegreeType) -> Result<(), EvalError<T>> {
         if self.rows() + self.block_size as DegreeType >= max_len {
             return Err(EvalError::RowsExhausted);
         }
@@ -366,7 +366,7 @@ impl<T: FieldElement> BlockMachine<T> {
         } else if !errors.is_empty() {
             Err(errors
                 .into_iter()
-                .reduce(|x: EvalError, y| x.combine(y))
+                .reduce(|x: EvalError<T>, y| x.combine(y))
                 .unwrap())
         } else {
             Err("Could not assign all variables in the query - maybe the machine does not have enough constraints?".to_string().into())

--- a/executor/src/witgen/machines/fixed_lookup_machine.rs
+++ b/executor/src/witgen/machines/fixed_lookup_machine.rs
@@ -236,11 +236,11 @@ impl<T: FieldElement> FixedLookup<T> {
                 output_columns.clone(),
             )
             .ok_or_else(|| {
-                let query_string = input_assignment
-                    .iter()
-                    .map(|(poly_ref, v)| format!("{} = {}", poly_ref.name, v))
-                    .join(", ");
-                EvalError::FixedLookupFailed(query_string)
+                let input_assignment = input_assignment
+                    .into_iter()
+                    .map(|(poly_ref, v)| (poly_ref.name.clone(), v))
+                    .collect();
+                EvalError::FixedLookupFailed(input_assignment)
             })?;
 
         let row = match index_value.row() {

--- a/executor/src/witgen/machines/machine_extractor.rs
+++ b/executor/src/witgen/machines/machine_extractor.rs
@@ -8,7 +8,6 @@ use super::sorted_witness_machine::SortedWitnesses;
 use super::FixedData;
 use super::Machine;
 use crate::witgen::range_constraints::RangeConstraint;
-use crate::witgen::WitnessColumn;
 use ast::analyzed::{Expression, Identity, IdentityKind, PolynomialReference, SelectedExpressions};
 use itertools::Itertools;
 use number::FieldElement;
@@ -26,14 +25,13 @@ pub struct ExtractionOutput<'a, T> {
 pub fn split_out_machines<'a, T: FieldElement>(
     fixed: &'a FixedData<'a, T>,
     identities: Vec<&'a Identity<T>>,
-    witness_cols: &'a [WitnessColumn<T>],
     global_range_constraints: &BTreeMap<&'a PolynomialReference, RangeConstraint<T>>,
 ) -> ExtractionOutput<'a, T> {
     let fixed_lookup = FixedLookup::try_new(fixed, &[], &Default::default()).unwrap();
 
     let mut machines: Vec<Box<dyn Machine<T>>> = vec![];
 
-    let all_witnesses: HashSet<&'a _> = witness_cols.iter().map(|c| &c.poly).collect();
+    let all_witnesses: HashSet<&'a _> = fixed.witness_cols.iter().map(|c| &c.poly).collect();
     let mut remaining_witnesses = all_witnesses.clone();
     let mut base_identities = identities.clone();
     for id in &identities {

--- a/executor/src/witgen/util.rs
+++ b/executor/src/witgen/util.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use ast::analyzed::util::previsit_expressions_in_identity_mut;
-use ast::analyzed::{Expression, Identity, PolyID, PolynomialReference};
+use ast::analyzed::{Expression, Identity, PolynomialReference};
 
 /// Checks if an expression is
 /// - a polynomial
@@ -23,15 +23,12 @@ pub fn try_to_simple_poly<T>(expr: &Expression<T>) -> Option<&PolynomialReferenc
     }
 }
 
-pub fn try_to_simple_poly_ref<T>(expr: &Expression<T>) -> Option<PolyID> {
-    if let Expression::PolynomialReference(PolynomialReference {
-        poly_id,
-        index: None,
-        next: false,
-        ..
-    }) = expr
-    {
-        Some(poly_id.unwrap())
+pub fn try_to_simple_poly_ref<T>(expr: &Expression<T>) -> Option<&PolynomialReference> {
+    if let Expression::PolynomialReference(poly_ref) = expr {
+        if poly_ref.index.is_none() && !poly_ref.next {
+            return Some(poly_ref);
+        }
+        None
     } else {
         None
     }


### PR DESCRIPTION
I read and stepped through the witness generation code, very cool stuff!

On the way, I did some small refactorings, added comments, improved error messages and increased trace logging.

Some notable changes:
- A failed fixed lookup now reports the query
- In trace log level, it now reports how values are derived (for the main SM and block state machines)
  - I was a bit worried about slowing the execution with trace logging, so I set `features = ["release_max_level_debug"]` in the `log` crate, so trace logging strings are never built in release mode
- Panics if not enough inputs are provided by the prover
- The looping period is detected using only the witness columns of the main SM
- If witness generation fails for a given row, it also prints the missing values of the previous row. In the case of underconstrained VMs, failed witness generation is often caused by values not being defined in the previous row.

This is an example of the trace logs:
```
$ RUST_LOG=trace cargo run pil -f test_data/asm/simple_sum.asm -i 3,2,2,1
...
Row: 0
  Strategy: SingleVariableAffine
    Processing: (main.first_step * main.A) = 0;
      => main.A = 0
    Processing: (main.first_step * main.CNT) = 0;
      => main.CNT = 0
    Processing: main.pc' = ((1 - main.first_step') * (((main.instr_jmpz * ((main.XIsZero * main.instr_jmpz_param_l) + ((1 - main.XIsZero) * (main.pc + 1)))) + (main.instr_jmp * main.instr_jmp_param_l)) + ((1 - (main.instr_jmpz + main.instr_jmp)) * (main.pc + 1))));
      => main.pc' = 0
Generating index for lookup in columns (in: main.p_line, out: main.p_X_read_free, main.p_instr_assert_zero, main.p_instr_dec_CNT, main.p_instr_jmp, main.p_instr_jmp_param_l, main.p_instr_jmpz, main.p_instr_jmpz_param_l, main.p_read_X_A, main.p_read_X_CNT, main.p_reg_write_X_A, main.p_reg_write_X_CNT)
Done creating index. Size (as flat list): entries * (num_inputs * input_size + row_pointer_size) = 8 * (1 * 8 bytes + 8 bytes) = 128 bytes
    Processing: { main.pc, main.reg_write_X_A, main.reg_write_X_CNT, main.instr_jmpz, main.instr_jmpz_param_l, main.instr_jmp, main.instr_jmp_param_l, main.instr_dec_CNT, main.instr_assert_zero, main.X_read_free, main.read_X_A, main.read_X_CNT } in { main.p_line, main.p_reg_write_X_A, main.p_reg_write_X_CNT, main.p_instr_jmpz, main.p_instr_jmpz_param_l, main.p_instr_jmp, main.p_instr_jmp_param_l, main.p_instr_dec_CNT, main.p_instr_assert_zero, main.p_X_read_free, main.p_read_X_A, main.p_read_X_CNT };
      => main.reg_write_X_A = 0
      => main.reg_write_X_CNT = 1
      => main.instr_jmpz = 0
      => main.instr_jmpz_param_l = 0
      => main.instr_jmp = 0
      => main.instr_jmp_param_l = 0
      => main.instr_dec_CNT = 0
      => main.instr_assert_zero = 0
      => main.X_read_free = 1
      => main.read_X_A = 0
      => main.read_X_CNT = 0
Input query: Index 1 -> 2
    Processing: <query>
      => main.X_free_value = 2
    Processing: main.X = (((main.read_X_A * main.A) + (main.read_X_CNT * main.CNT)) + (main.X_read_free * main.X_free_value));
      => main.X = 2
    Processing: (main.XIsZero * main.X) = 0;
      => main.XIsZero = 0
    Processing: main.XIsZero = (1 - (main.X * main.XInv));
      => main.XInv = -9223372034707292160
  Strategy: AssumeZero
===== Row 0:
    main.X = 2
    main.reg_write_X_CNT = 1
    main.XInv = -9223372034707292160
    main.X_read_free = 1
    main.X_free_value = 2
    main.pc = 0
    main.reg_write_X_A = 0
    main.A = 0
    main.CNT = 0
    main.XIsZero = 0
    main.instr_jmpz = 0
    main.instr_jmpz_param_l = 0
    main.instr_jmp = 0
    main.instr_jmp_param_l = 0
    main.instr_dec_CNT = 0
    main.instr_assert_zero = 0
    main.read_X_A = 0
    main.read_X_CNT = 0
Row: 1
  Strategy: SingleVariableAffine
    Processing: main.A' = ((main.reg_write_X_A * main.X) + ((1 - (main.first_step' + main.reg_write_X_A)) * main.A));
      => main.A' = 0
    Processing: main.CNT' = (((main.reg_write_X_CNT * main.X) + (main.instr_dec_CNT * (main.CNT - 1))) + ((1 - ((main.first_step' + main.reg_write_X_CNT) + main.instr_dec_CNT)) * main.CNT));
      => main.CNT' = 2
    Processing: main.pc' = ((1 - main.first_step') * (((main.instr_jmpz * ((main.XIsZero * main.instr_jmpz_param_l) + ((1 - main.XIsZero) * (main.pc + 1)))) + (main.instr_jmp * main.instr_jmp_param_l)) + ((1 - (main.instr_jmpz + main.instr_jmp)) * (main.pc + 1))));
      => main.pc' = 1
    Processing: { main.pc, main.reg_write_X_A, main.reg_write_X_CNT, main.instr_jmpz, main.instr_jmpz_param_l, main.instr_jmp, main.instr_jmp_param_l, main.instr_dec_CNT, main.instr_assert_zero, main.X_read_free, main.read_X_A, main.read_X_CNT } in { main.p_line, main.p_reg_write_X_A, main.p_reg_write_X_CNT, main.p_instr_jmpz, main.p_instr_jmpz_param_l, main.p_instr_jmp, main.p_instr_jmp_param_l, main.p_instr_dec_CNT, main.p_instr_assert_zero, main.p_X_read_free, main.p_read_X_A, main.p_read_X_CNT };
      => main.reg_write_X_A = 0
      => main.reg_write_X_CNT = 0
      => main.instr_jmpz = 1
      => main.instr_jmpz_param_l = 5
      => main.instr_jmp = 0
      => main.instr_jmp_param_l = 0
      => main.instr_dec_CNT = 0
      => main.instr_assert_zero = 0
      => main.X_read_free = 0
      => main.read_X_A = 0
      => main.read_X_CNT = 1
    Processing: main.X = (((main.read_X_A * main.A) + (main.read_X_CNT * main.CNT)) + (main.X_read_free * main.X_free_value));
      => main.X = 2
    Processing: (main.XIsZero * main.X) = 0;
      => main.XIsZero = 0
    Processing: main.XIsZero = (1 - (main.X * main.XInv));
      => main.XInv = -9223372034707292160
  Strategy: AssumeZero
===== Row 1:
    main.pc = 1
    main.X = 2
    main.CNT = 2
    main.XInv = -9223372034707292160
    main.instr_jmpz = 1
    main.instr_jmpz_param_l = 5
    main.read_X_CNT = 1
    main.reg_write_X_A = 0
    main.A = 0
    main.reg_write_X_CNT = 0
    main.XIsZero = 0
    main.instr_jmp = 0
    main.instr_jmp_param_l = 0
    main.instr_dec_CNT = 0
    main.instr_assert_zero = 0
    main.X_read_free = 0
    main.read_X_A = 0
    main.X_free_value = <unknown>
```